### PR TITLE
feat: synchronize wrapper class for overlay groups on reuse

### DIFF
--- a/packages/core/src/builder.ts
+++ b/packages/core/src/builder.ts
@@ -594,10 +594,13 @@ class VizBuilderImpl implements VizBuilder {
         }
 
         // Keep wrapper class in sync even when reusing an existing group.
-        group.setAttribute(
-          'class',
-          `viz-overlay-${spec.id}${spec.className ? ` ${spec.className}` : ''}`
-        );
+        const expectedClass = `viz-overlay-${spec.id}${
+          spec.className ? ` ${spec.className}` : ''
+        }`;
+        const currentClass = group.getAttribute('class');
+        if (currentClass !== expectedClass) {
+          group.setAttribute('class', expectedClass);
+        }
 
         const overlayCtx = {
           spec,


### PR DESCRIPTION
This pull request makes a small but important adjustment to the logic for managing SVG overlay groups in the `VizBuilderImpl` class. The main improvement is ensuring that the overlay group's CSS class is always updated, even when an existing group is reused, which helps keep the DOM in sync with the current visualization state.

- Overlay group management:
  * Ensures that the `class` attribute for overlay groups is updated every time, not just when the group is created, by moving the class assignment outside the conditional block that creates the group. This prevents stale classes when reusing existing groups. [[1]](diffhunk://#diff-9ea843896bf96354d12e0083572e01fb8ab10eb957055f1db15434d7204ab88eR592-L598) [[2]](diffhunk://#diff-9ea843896bf96354d12e0083572e01fb8ab10eb957055f1db15434d7204ab88eR1057-L1061)