### PR TITLE
feat: add container/group nodes (swimlanes) (#23)

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,26 @@ b.node('n1')
  .label('Text', { dy: 5 }) // Label with offset
  .class('css-class')     // Custom CSS class
  .data({ ... })          // Attach custom data
+ .container(config?)     // Mark as container / group node
+ .parent('containerId')  // Make child of a container
 ```
+
+### Container / Group Nodes
+
+Group related nodes into visual containers (swimlanes, sub-processes, etc.).
+
+```typescript
+b.node('lane')
+ .at(250, 170)
+ .rect(460, 300)
+ .label('Process Phase')
+ .container({ headerHeight: 36 })
+
+b.node('step1').at(150, 220).rect(100, 50).parent('lane')
+b.node('step2').at(350, 220).rect(100, 50).parent('lane')
+```
+
+Container children are nested inside the container `<g>` in the SVG and follow the container when moved at runtime.
 
 ### Edges
 Edges connect nodes and can be styled, directed, or animated.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -123,7 +123,26 @@ b.node('n1')
  .label('Text', { dy: 5 }) // Label with offset
  .class('css-class')     // Custom CSS class
  .data({ ... })          // Attach custom data
+ .container(config?)     // Mark as container / group node
+ .parent('containerId')  // Make child of a container
 ```
+
+### Container / Group Nodes
+
+Group related nodes into visual containers (swimlanes, sub-processes, etc.).
+
+```typescript
+b.node('lane')
+  .at(250, 170)
+  .rect(460, 300)
+  .label('Process Phase')
+  .container({ headerHeight: 36 });
+
+b.node('step1').at(150, 220).rect(100, 50).parent('lane');
+b.node('step2').at(350, 220).rect(100, 50).parent('lane');
+```
+
+Container children are nested inside the container `<g>` in the SVG and follow the container when moved at runtime.
 
 ### Edges
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -91,6 +91,17 @@ export type VizRuntimeEdgeProps = Partial<{
   opacity: number;
 }>;
 
+export interface ContainerConfig {
+  /** Layout direction for children (default 'free') */
+  layout?: 'free' | 'vertical' | 'horizontal';
+  /** Padding inside the container */
+  padding?: { top: number; right: number; bottom: number; left: number };
+  /** Whether the container auto-resizes to fit children */
+  autoSize?: boolean;
+  /** Header height for swimlane-style headers */
+  headerHeight?: number;
+}
+
 export interface VizNode {
   id: string;
   pos: Vec2;
@@ -107,6 +118,11 @@ export interface VizNode {
   data?: unknown; // User payload
   onClick?: (id: string, node: VizNode) => void;
   animations?: VizAnimSpec[];
+
+  /** If set, this node is a child of the node with this id. */
+  parentId?: string;
+  /** Container-specific configuration (only on parent nodes). */
+  container?: ContainerConfig;
 }
 
 export interface EdgeLabel {

--- a/packages/docs/docs/essentials.mdx
+++ b/packages/docs/docs/essentials.mdx
@@ -309,3 +309,90 @@ if (container) builder.mount(container);
 For a full breakdown (registry/CSS animations, data-only timelines, playback controls, and live examples), see the dedicated guide:
 
 - [Animations](./animations)
+
+---
+
+## Container / Group Nodes
+
+Container nodes let you group children visually — think swimlanes, sub-processes,
+or architectural boxes. Mark any node as a container with `.container()`, then
+attach children with `.parent(containerId)`.
+
+export const containerBuilder = viz().view(500, 340);
+export const containerScene = containerBuilder
+  .node('swim')
+  .at(250, 170)
+  .rect(460, 300)
+  .label('Swimlane')
+  .fill('#f0f4ff')
+  .stroke('#4a6fa5', 2)
+  .container({ headerHeight: 36 })
+  .node('step1')
+  .at(150, 220)
+  .rect(100, 50)
+  .label('Step 1')
+  .parent('swim')
+  .node('step2')
+  .at(350, 220)
+  .rect(100, 50)
+  .label('Step 2')
+  .parent('swim')
+  .edge('step1', 'step2')
+  .arrow()
+  .done();
+
+<CodePreview code={`
+import { viz } from 'vizcraft';
+
+const builder = viz().view(500, 340);
+
+builder
+.node('swim')
+.at(250, 170)
+.rect(460, 300)
+.label('Swimlane')
+.fill('#f0f4ff')
+.stroke('#4a6fa5', 2)
+.container({ headerHeight: 36 })
+.node('step1')
+.at(150, 220)
+.rect(100, 50)
+.label('Step 1')
+.parent('swim')
+.node('step2')
+.at(350, 220)
+.rect(100, 50)
+.label('Step 2')
+.parent('swim')
+.edge('step1', 'step2')
+.arrow()
+.done();
+
+const el = document.getElementById('viz-container');
+if (el) builder.mount(el);
+`}>
+
+  <VizMount builder={containerScene} style={{ height: '340px', width: '100%' }} />
+</CodePreview>
+
+### How it works
+
+| Builder method        | Effect                                                                        |
+| --------------------- | ----------------------------------------------------------------------------- |
+| `.container(config?)` | Marks the current node as a container. Accepts an optional `ContainerConfig`. |
+| `.parent(id)`         | Makes the current node a child of the container with the given id.            |
+
+**`ContainerConfig` options:**
+
+- `layout` — `'free'` (default), `'vertical'`, or `'horizontal'`.
+- `padding` — `{ top, right, bottom, left }` interior padding.
+- `autoSize` — whether the container auto-resizes to fit children.
+- `headerHeight` — height of the header band; renders a separator line and centres the container label in the header area.
+
+Children's positions are specified in **absolute** scene coordinates. When a container moves at runtime (via `patchRuntime`), all its children are automatically offset by the same delta.
+
+In the rendered SVG:
+
+- Container nodes receive the `viz-container` CSS class.
+- Children are nested inside a `<g class="viz-container-children">` group.
+- The header line has the class `viz-container-header`.

--- a/packages/docs/docs/types.mdx
+++ b/packages/docs/docs/types.mdx
@@ -40,6 +40,19 @@ A node in the scene graph.
 - `runtime?: VizRuntimeNodeProps` — **runtime-only** overrides (what the animation system writes).
 - `animations?: VizAnimSpec[]` — registry/CSS animation requests (e.g. `pulse`, `flow`).
 - `data?: unknown` — your payload.
+- `parentId?: string` — parent container node id (makes this node a child of that container).
+- `container?: ContainerConfig` — marks this node as a container and configures grouping behaviour.
+
+---
+
+## ContainerConfig
+
+Configuration for a container / group node. Applied via `.container(config?)` on the builder.
+
+- `layout?: 'free' | 'vertical' | 'horizontal'` — child layout direction (default `'free'`).
+- `padding?: { top: number; right: number; bottom: number; left: number }` — interior padding.
+- `autoSize?: boolean` — whether the container auto-resizes to fit children.
+- `headerHeight?: number` — height of the header band for swimlane-style headers. When set, a separator line is rendered at this offset from the container's top edge and the node label is centred inside the header area.
 
 ---
 


### PR DESCRIPTION
- Add ContainerConfig type and parentId/container fields to VizNode
- Add .container(config?) and .parent(parentId) to builder API
- Update SVG string rendering with recursive container nesting
- Update DOM mount rendering with recursive reconciliation
- Update React VizCanvas with RenderNodeGroup component
- Update runtimePatcher to propagate container position deltas
- Render header separator line when headerHeight is set
- Center container label in header area
- Add 7 container tests (67 total)
- Update docs: types.mdx, essentials.mdx (interactive example), READMEs

Closes #23