### PR TITLE
feat: add VizBuilder.destroy() API for clean unmounting

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Common lifecycle:
 
 - `builder.build()` creates a serializable `VizScene`.
 - `builder.mount(container)` renders into an SVG inside your container.
+- `builder.destroy()` tears down a mounted scene securely, cleaning up DOM and event listeners.
 - `builder.play()` plays any compiled timeline specs.
 - `builder.patchRuntime(container)` applies runtime-only updates (useful for per-frame updates without remounting).
 

--- a/packages/docs/docs/essentials.mdx
+++ b/packages/docs/docs/essentials.mdx
@@ -223,6 +223,22 @@ if (container) builder.mount(container);
   />
 </CodePreview>
 
+### Mounting and Destroying
+
+Once a scene is built, you render it to the DOM by passing an `HTMLElement` to `builder.mount()`. This injects the SVG and sets up any requested controllers (like pan/zoom).
+
+When you are done with a visualization — for example, when navigating away from a page or switching diagrams — you should call `builder.destroy()`. 
+
+```typescript
+// Render the scene
+builder.mount(containerElement);
+
+// Later, when cleaning up:
+builder.destroy();
+```
+
+Calling `destroy()` removes the SVG from the DOM, destroys the pan/zoom controller, cancels animation loops, and cleans up internal event listeners.
+
 ## Declarative Options Overloads
 
 Instead of chaining many fluent methods, you can also pass an **options object** as the second argument to `.node()` or the third argument to `.edge()`. This configures the element in a single call and returns the `VizBuilder` so you can continue adding more elements.


### PR DESCRIPTION
This pull request adds a new `destroy()` lifecycle method to the `VizBuilder` API, enabling clean teardown of mounted visualizations. The implementation ensures that all DOM elements, controllers, animations, and event listeners are properly cleaned up. Comprehensive tests and documentation have been added to support this new feature.

**Lifecycle management improvements:**

* Added a `destroy()` method to the `VizBuilder` interface and its implementation, which removes the SVG from the container, destroys the PanZoomController, cancels animations, and cleans up event listeners. The method is safe to call multiple times or if `mount()` was never called. (`packages/core/src/builder.ts`) [[1]](diffhunk://#diff-9ea843896bf96354d12e0083572e01fb8ab10eb957055f1db15434d7204ab88eR317-R329) [[2]](diffhunk://#diff-9ea843896bf96354d12e0083572e01fb8ab10eb957055f1db15434d7204ab88eR660) [[3]](diffhunk://#diff-9ea843896bf96354d12e0083572e01fb8ab10eb957055f1db15434d7204ab88eR1095-R1134)
* Updated the lifecycle API documentation in `README.md` to include `builder.destroy()` and describe its behavior. (`README.md`)
* Added a new "Mounting and Destroying" section to the docs, with usage examples and explanations for `destroy()`. (`packages/docs/docs/essentials.mdx`)

**Testing enhancements:**

* Introduced a suite of tests covering the `destroy()` method, verifying DOM cleanup, controller destruction, animation stopping, no-op safety, and remounting after destruction. (`packages/core/src/index.test.ts`) [[1]](diffhunk://#diff-47b6fb65469ce87ac5bbf4d85dcc4135eca0e4f9debafd8a13f0865db99c5f9bR3303-R3354) [[2]](diffhunk://#diff-47b6fb65469ce87ac5bbf4d85dcc4135eca0e4f9debafd8a13f0865db99c5f9bL4-R4)

Closes #62 