### PR TITLE
fix: prevent stale runtimePatchCtx from overwriting node stroke-dasha…

### DIFF
--- a/packages/core/src/builder.ts
+++ b/packages/core/src/builder.ts
@@ -1322,14 +1322,13 @@ class VizBuilderImpl implements VizBuilder {
     const scene = this.build();
     this._renderSceneToDOM(scene, container);
 
-    // Apply runtime overrides (if any)
-    let ctx = runtimePatchCtxBySvg.get(svg);
-    if (!ctx) {
-      ctx = createRuntimePatchCtx(svg, {
-        edgePathResolver: this._edgePathResolver,
-      });
-      runtimePatchCtxBySvg.set(svg, ctx);
-    }
+    // Apply runtime overrides (if any).
+    // Always recreate the context after _renderSceneToDOM so patchRuntime
+    // never references stale / detached elements (fixes #81).
+    const ctx = createRuntimePatchCtx(svg, {
+      edgePathResolver: this._edgePathResolver,
+    });
+    runtimePatchCtxBySvg.set(svg, ctx);
     patchRuntime(scene, ctx);
   }
 

--- a/packages/core/src/runtimePatcher.ts
+++ b/packages/core/src/runtimePatcher.ts
@@ -670,17 +670,9 @@ export function patchRuntime(scene: VizScene, ctx: RuntimePatchCtx) {
       }
     }
 
-    // Stroke-dasharray: apply resolved value to shape.
-    if (node.style?.strokeDasharray !== undefined) {
-      const resolved = resolveDasharray(node.style.strokeDasharray);
-      if (resolved) {
-        shape.setAttribute('stroke-dasharray', resolved);
-      } else {
-        shape.removeAttribute('stroke-dasharray');
-      }
-    } else {
-      shape.removeAttribute('stroke-dasharray');
-    }
+    // NOTE: strokeDasharray is a static base style — written exclusively by
+    // _renderSceneToDOM via setSvgAttributes.  patchRuntime must NOT duplicate
+    // that write to avoid the stale-context overwrite described in #81.
 
     if (node.style?.shadow) {
       const fid = ensureShadowFilter(ctx.svg, node.style.shadow);


### PR DESCRIPTION
…rray after commit (#81)

- Always recreate runtimePatchCtx in commit() after _renderSceneToDOM so patchRuntime never references stale/detached elements.
- Remove redundant node strokeDasharray write from patchRuntime; it is a static base style owned exclusively by _renderSceneToDOM.
- Add regression tests verifying updateNode + commit correctly renders stroke-dasharray through multiple cycles (solid/dashed/dotted/dash-dot).

Closes #81