### PR TITLE
feat(core): add text badge API (#108)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ VizCraft is designed to make creating beautiful, animated node-link diagrams and
 - **Framework Agnostic**: The core logic is pure TypeScript and can be used with any framework or Vanilla JS.
 - **Custom Overlays**: Create complex, custom UI elements that float on top of your visualization.
 - **Dangling Edges**: Create edges with free endpoints for drag-to-connect interactions.
+- **Text Badges**: Pin 1–2 character indicators (class kind, status, etc.) to any corner of a node.
 
 ## 📦 Installation
 
@@ -545,6 +546,7 @@ b.edge('a', 'b').stroke('#e74c3c', 3).fill('none').opacity(0.8)
 For deeper guides and API references, see [docs here](https://vizcraft-docs.vercel.app/docs/advanced).
 
 - **Interactivity**: attach `onClick` handlers and `.tooltip()` hover info to nodes/edges.
+- **Text badges**: pin corner indicators to nodes with `.badge(text, opts?)`.
 - **Overlays**: add non-node/edge visuals using `.overlay(id, params, key?)`.
 - **React integration**: see the workspace package [packages/react-vizcraft](packages/react-vizcraft) (monorepo).
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -22,6 +22,7 @@ VizCraft is designed to make creating beautiful, animated node-link diagrams and
 - **Framework Agnostic**: The core logic is pure TypeScript and can be used with any framework or Vanilla JS.
 - **Custom Overlays**: Create complex, custom UI elements that float on top of your visualization.
 - **Dangling Edges**: Create edges with free endpoints for drag-to-connect interactions.
+- **Text Badges**: Pin 1–2 character indicators (class kind, status, etc.) to any corner of a node.
 
 ## 📦 Installation
 

--- a/packages/core/src/builder.ts
+++ b/packages/core/src/builder.ts
@@ -30,6 +30,7 @@ import type {
   LayoutResult,
   SvgExportOptions,
   TooltipContent,
+  BadgePosition,
 } from './types';
 import { OVERLAY_RUNTIME_DIRTY } from './types';
 import { setupPanZoom } from './interaction/panZoom';
@@ -70,6 +71,7 @@ import {
   effectiveShape,
   getShapeBehavior,
   shapeSvgMarkup,
+  getNodeBoundingBox,
 } from './shapes/geometry';
 import { getEffectiveNodeBounds } from './interaction/hitTest';
 import { defaultCoreIconRegistry } from './shapes/icons';
@@ -679,6 +681,21 @@ export interface NodeBuilder {
   compartment(id: string, cb?: (c: CompartmentBuilder) => unknown): NodeBuilder;
   /** Set tooltip content shown on hover/focus. */
   tooltip(content: TooltipContent): NodeBuilder;
+  /**
+   * Add a text badge pinned to a corner of the node.
+   *
+   * @param text       1–2 character badge text
+   * @param opts       Badge options (position, colors, fontSize)
+   */
+  badge(
+    text: string,
+    opts?: {
+      position?: BadgePosition;
+      fill?: string;
+      background?: string;
+      fontSize?: number;
+    }
+  ): NodeBuilder;
   done(): VizBuilder;
 
   // Seamless chaining extensions
@@ -2654,6 +2671,66 @@ class VizBuilderImpl implements VizBuilder {
         ) as SVGTextElement | null;
       }
 
+      // Badges — small text indicators pinned to node corners
+      const oldBadges = group.querySelectorAll('[data-viz-role="badge"]');
+      oldBadges.forEach((el) => el.remove());
+
+      if (node.badges && node.badges.length > 0) {
+        const bbox = getNodeBoundingBox(node.shape);
+        const hw = bbox.width / 2;
+        const hh = bbox.height / 2;
+
+        for (const badge of node.badges) {
+          const fs = badge.fontSize ?? 10;
+          const pad = 3;
+          const pillH = fs + pad * 2;
+          const pillW = Math.max(fs * badge.text.length * 0.7 + pad * 2, pillH);
+
+          let bx: number;
+          let by: number;
+          if (badge.position === 'top-left') {
+            bx = x - hw - pillW / 4;
+            by = y - hh - pillH / 4;
+          } else if (badge.position === 'top-right') {
+            bx = x + hw - (pillW * 3) / 4;
+            by = y - hh - pillH / 4;
+          } else if (badge.position === 'bottom-left') {
+            bx = x - hw - pillW / 4;
+            by = y + hh - (pillH * 3) / 4;
+          } else {
+            bx = x + hw - (pillW * 3) / 4;
+            by = y + hh - (pillH * 3) / 4;
+          }
+
+          const badgeG = document.createElementNS(svgNS, 'g');
+          badgeG.setAttribute('class', 'viz-badge');
+          badgeG.setAttribute('data-viz-role', 'badge');
+
+          if (badge.background) {
+            const pill = document.createElementNS(svgNS, 'rect');
+            pill.setAttribute('x', String(bx));
+            pill.setAttribute('y', String(by));
+            pill.setAttribute('width', String(pillW));
+            pill.setAttribute('height', String(pillH));
+            pill.setAttribute('rx', String(pillH / 2));
+            pill.setAttribute('fill', badge.background);
+            badgeG.appendChild(pill);
+          }
+
+          const txt = document.createElementNS(svgNS, 'text');
+          txt.setAttribute('x', String(bx + pillW / 2));
+          txt.setAttribute('y', String(by + pillH / 2));
+          txt.setAttribute('text-anchor', 'middle');
+          txt.setAttribute('dominant-baseline', 'central');
+          txt.setAttribute('font-size', String(fs));
+          if (badge.fill) txt.setAttribute('fill', badge.fill);
+          txt.textContent = badge.text;
+          badgeG.appendChild(txt);
+
+          group.appendChild(badgeG);
+        }
+      }
+
       // Ports — render small circles at each explicit port position.
       // Remove stale ports first, then recreate from current spec.
       const oldPorts = group.querySelectorAll('[data-viz-role="port"]');
@@ -3332,6 +3409,51 @@ class VizBuilderImpl implements VizBuilder {
           '<text data-viz-role="node-label" '
         );
         content += augmentedSvg;
+      }
+
+      // Badges — small text indicators pinned to node corners
+      if (node.badges && node.badges.length > 0) {
+        const bbox = getNodeBoundingBox(shape);
+        const hw = bbox.width / 2;
+        const hh = bbox.height / 2;
+
+        for (const badge of node.badges) {
+          const fs = badge.fontSize ?? 10;
+          const pad = 3;
+          const pillH = fs + pad * 2;
+          const pillW = Math.max(fs * badge.text.length * 0.7 + pad * 2, pillH);
+
+          let bx: number;
+          let by: number;
+          if (badge.position === 'top-left') {
+            bx = x - hw - pillW / 4;
+            by = y - hh - pillH / 4;
+          } else if (badge.position === 'top-right') {
+            bx = x + hw - (pillW * 3) / 4;
+            by = y - hh - pillH / 4;
+          } else if (badge.position === 'bottom-left') {
+            bx = x - hw - pillW / 4;
+            by = y + hh - (pillH * 3) / 4;
+          } else {
+            bx = x + hw - (pillW * 3) / 4;
+            by = y + hh - (pillH * 3) / 4;
+          }
+
+          content += '<g class="viz-badge" data-viz-role="badge">';
+          if (badge.background) {
+            const safeBg = escapeXmlAttr(badge.background);
+            content += `<rect x="${bx}" y="${by}" width="${pillW}" height="${pillH}" rx="${pillH / 2}" fill="${safeBg}" />`;
+          }
+          const safeFill = badge.fill
+            ? ` fill="${escapeXmlAttr(badge.fill)}"`
+            : '';
+          const safeText = badge.text
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;');
+          content += `<text x="${bx + pillW / 2}" y="${by + pillH / 2}" text-anchor="middle" dominant-baseline="central" font-size="${fs}"${safeFill}>${safeText}</text>`;
+          content += '</g>';
+        }
       }
 
       // Ports (small circles on the shape boundary, hidden by default, shown on hover via CSS)

--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -5162,3 +5162,181 @@ describe('vizcraft core', () => {
     });
   });
 });
+
+// ---------------------------------------------------------------------------
+// Text Badge API (#108)
+// ---------------------------------------------------------------------------
+describe('Text Badge API', () => {
+  it('stores a single badge on a node via fluent API', () => {
+    const scene = viz()
+      .node('n')
+      .at(0, 0)
+      .rect(100, 60)
+      .badge('C', {
+        position: 'top-left',
+        fill: '#4a9eff',
+        background: '#1a2c42',
+      })
+      .done()
+      .build();
+
+    expect(scene.nodes[0]!.badges).toHaveLength(1);
+    expect(scene.nodes[0]!.badges![0]).toEqual({
+      text: 'C',
+      position: 'top-left',
+      fill: '#4a9eff',
+      background: '#1a2c42',
+      fontSize: undefined,
+    });
+  });
+
+  it('supports multiple badges on a node', () => {
+    const scene = viz()
+      .node('n')
+      .at(0, 0)
+      .rect(100, 60)
+      .badge('C', { position: 'top-left' })
+      .badge('\u26A1', { position: 'top-right' })
+      .done()
+      .build();
+
+    expect(scene.nodes[0]!.badges).toHaveLength(2);
+    expect(scene.nodes[0]!.badges![0]!.position).toBe('top-left');
+    expect(scene.nodes[0]!.badges![1]!.position).toBe('top-right');
+  });
+
+  it('defaults position to top-left when omitted', () => {
+    const scene = viz().node('n').at(0, 0).circle(30).badge('I').done().build();
+
+    expect(scene.nodes[0]!.badges![0]!.position).toBe('top-left');
+  });
+
+  it('sets badge via declarative NodeOptions', () => {
+    const scene = viz()
+      .node('n', {
+        at: { x: 0, y: 0 },
+        rect: { w: 100, h: 60 },
+        badges: [{ text: 'T', position: 'top-right', fill: '#ccc' }],
+      })
+      .build();
+
+    expect(scene.nodes[0]!.badges).toHaveLength(1);
+    expect(scene.nodes[0]!.badges![0]!.text).toBe('T');
+    expect(scene.nodes[0]!.badges![0]!.position).toBe('top-right');
+  });
+
+  it('renders badge SVG elements when mounted', () => {
+    const container = document.createElement('div');
+    const builder = viz()
+      .node('n')
+      .at(50, 50)
+      .rect(100, 60)
+      .badge('C', { position: 'top-left', fill: '#fff', background: '#333' })
+      .done();
+
+    builder.mount(container);
+
+    const svg = container.querySelector('svg')!;
+    const badgeGroups = svg.querySelectorAll('[data-viz-role="badge"]');
+    expect(badgeGroups).toHaveLength(1);
+
+    const pill = badgeGroups[0]!.querySelector('rect');
+    expect(pill).not.toBeNull();
+    expect(pill!.getAttribute('fill')).toBe('#333');
+
+    const text = badgeGroups[0]!.querySelector('text');
+    expect(text).not.toBeNull();
+    expect(text!.textContent).toBe('C');
+    expect(text!.getAttribute('fill')).toBe('#fff');
+
+    builder.destroy();
+  });
+
+  it('renders badge without background (no pill rect)', () => {
+    const container = document.createElement('div');
+    const builder = viz()
+      .node('n')
+      .at(50, 50)
+      .rect(100, 60)
+      .badge('I', { position: 'top-left', fill: '#4a9eff' })
+      .done();
+
+    builder.mount(container);
+
+    const svg = container.querySelector('svg')!;
+    const badgeGroup = svg.querySelector('[data-viz-role="badge"]')!;
+    expect(badgeGroup.querySelector('rect')).toBeNull();
+    expect(badgeGroup.querySelector('text')!.textContent).toBe('I');
+
+    builder.destroy();
+  });
+
+  it('includes badges in SVG export', () => {
+    const svgStr = viz()
+      .node('n')
+      .at(50, 50)
+      .rect(100, 60)
+      .badge('C', { position: 'top-left', fill: '#fff', background: '#333' })
+      .done()
+      .svg();
+
+    expect(svgStr).toContain('data-viz-role="badge"');
+    expect(svgStr).toContain('>C</text>');
+    expect(svgStr).toContain('fill="#333"');
+  });
+
+  it('supports custom fontSize', () => {
+    const scene = viz()
+      .node('n')
+      .at(0, 0)
+      .rect(100, 60)
+      .badge('x', { fontSize: 14 })
+      .done()
+      .build();
+
+    expect(scene.nodes[0]!.badges![0]!.fontSize).toBe(14);
+  });
+
+  it('preserves chaining after badge()', () => {
+    const scene = viz()
+      .node('n')
+      .at(0, 0)
+      .rect(100, 60)
+      .badge('C', { position: 'top-left' })
+      .label('MyClass')
+      .fill('#eee')
+      .done()
+      .build();
+
+    expect(scene.nodes[0]!.badges).toHaveLength(1);
+    expect(scene.nodes[0]!.label!.text).toBe('MyClass');
+    expect(scene.nodes[0]!.style!.fill).toBe('#eee');
+  });
+
+  it('nodes without badges have undefined badges', () => {
+    const scene = viz().node('n').at(0, 0).rect(100, 60).done().build();
+
+    expect(scene.nodes[0]!.badges).toBeUndefined();
+  });
+
+  it('renders badges at all four corners', () => {
+    const container = document.createElement('div');
+    const builder = viz()
+      .node('n')
+      .at(100, 100)
+      .rect(100, 60)
+      .badge('1', { position: 'top-left' })
+      .badge('2', { position: 'top-right' })
+      .badge('3', { position: 'bottom-left' })
+      .badge('4', { position: 'bottom-right' })
+      .done();
+
+    builder.mount(container);
+
+    const svg = container.querySelector('svg')!;
+    const badges = svg.querySelectorAll('[data-viz-role="badge"]');
+    expect(badges).toHaveLength(4);
+
+    builder.destroy();
+  });
+});

--- a/packages/core/src/nodes/builder.ts
+++ b/packages/core/src/nodes/builder.ts
@@ -11,6 +11,7 @@ import type {
   VizScene,
   SvgExportOptions,
   TooltipContent,
+  BadgePosition,
 } from '../types';
 import type {
   VizBuilder,
@@ -141,6 +142,18 @@ export function applyNodeOptions(nb: NodeBuilder, opts: NodeOptions): void {
   if (opts.data !== undefined) nb.data(opts.data);
   if (opts.onClick) nb.onClick(opts.onClick);
   if (opts.tooltip !== undefined) nb.tooltip(opts.tooltip);
+
+  // Badges
+  if (opts.badges) {
+    for (const b of opts.badges) {
+      nb.badge(b.text, {
+        position: b.position,
+        fill: b.fill,
+        background: b.background,
+        fontSize: b.fontSize,
+      });
+    }
+  }
 
   // Ports
   if (opts.ports) {
@@ -746,6 +759,28 @@ export class NodeBuilderImpl implements NodeBuilder {
 
   tooltip(content: TooltipContent): NodeBuilder {
     this.nodeDef.tooltip = content;
+    return this;
+  }
+
+  badge(
+    text: string,
+    opts?: {
+      position?: BadgePosition;
+      fill?: string;
+      background?: string;
+      fontSize?: number;
+    }
+  ): NodeBuilder {
+    if (!this.nodeDef.badges) {
+      this.nodeDef.badges = [];
+    }
+    this.nodeDef.badges.push({
+      text,
+      position: opts?.position ?? 'top-left',
+      fill: opts?.fill,
+      background: opts?.background,
+      fontSize: opts?.fontSize,
+    });
     return this;
   }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -95,6 +95,31 @@ export type TooltipContent =
       sections: TooltipSection[];
     };
 
+// ---------------------------------------------------------------------------
+// Badge types
+// ---------------------------------------------------------------------------
+
+/** Corner position for a text badge on a node. */
+export type BadgePosition =
+  | 'top-left'
+  | 'top-right'
+  | 'bottom-left'
+  | 'bottom-right';
+
+/** A small text badge indicator pinned to a corner of a node. */
+export interface VizNodeBadge {
+  /** 1–2 character text (icon / letter). */
+  text: string;
+  /** Corner to pin the badge to. */
+  position: BadgePosition;
+  /** Text color. */
+  fill?: string;
+  /** Optional pill background color. */
+  background?: string;
+  /** Font size in px (default 10). */
+  fontSize?: number;
+}
+
 export type NodeMediaPosition = 'center' | 'above' | 'below' | 'left' | 'right';
 
 export interface VizNodeImage {
@@ -388,6 +413,12 @@ export interface VizNode {
    * Pass a plain string for simple text or a structured object with sections.
    */
   tooltip?: TooltipContent;
+
+  /**
+   * Small text badges pinned to corners of the node.
+   * Each badge is a 1–2 character indicator with optional pill background.
+   */
+  badges?: VizNodeBadge[];
 }
 
 export interface EdgeLabel {
@@ -632,6 +663,16 @@ export interface NodeOptions {
   // --- Tooltip ---
   /** Tooltip shown on hover/focus. Plain string or structured `{ title?, sections }`. */
   tooltip?: TooltipContent;
+
+  // --- Badges ---
+  /** Text badges pinned to corners of the node. */
+  badges?: Array<{
+    text: string;
+    position: BadgePosition;
+    fill?: string;
+    background?: string;
+    fontSize?: number;
+  }>;
 
   // --- Ports ---
   ports?: Array<{

--- a/packages/docs/docs/how-to/nodes-and-shapes.mdx
+++ b/packages/docs/docs/how-to/nodes-and-shapes.mdx
@@ -328,6 +328,26 @@ export const richTextLabelScene = viz()
   )
   .done();
 
+export const badgeScene = viz()
+  .view(400, 120)
+  .node('cls')
+  .at(100, 60)
+  .rect(120, 50, 6)
+  .label('UserService')
+  .fill('#2d2d3d')
+  .stroke('#555')
+  .badge('C', { position: 'top-left', fill: '#fff', background: '#4a9eff', fontSize: 10 })
+  .done()
+  .node('iface')
+  .at(300, 60)
+  .rect(120, 50, 6)
+  .label('IRepository')
+  .fill('#2d2d3d')
+  .stroke('#555')
+  .badge('I', { position: 'top-left', fill: '#fff', background: '#e5c07b', fontSize: 10 })
+  .badge('\u0192', { position: 'top-right', fill: '#98c379' })
+  .done();
+
 # Nodes & Shapes
 
 This guide covers creating nodes, choosing shapes, styling them, and embedding media.
@@ -570,6 +590,47 @@ Two ways to position nodes:
 
 - **`.at(x, y)`** — absolute coordinates in the viewBox.
 - **`.cell(col, row)`** — grid-based positioning (requires `.grid()` on the builder).
+
+## Text badges
+
+Attach 1–2 character indicators (class kind, status icon, etc.) pinned to each corner of a node.
+
+<CodePreview code={`viz()
+  .node('cls').at(100, 60).rect(120, 50, 6)
+    .label('UserService').fill('#2d2d3d').stroke('#555')
+    .badge('C', { position: 'top-left', fill: '#fff', background: '#4a9eff', fontSize: 10 })
+  .done()
+  .node('iface').at(300, 60).rect(120, 50, 6)
+    .label('IRepository').fill('#2d2d3d').stroke('#555')
+    .badge('I', { position: 'top-left', fill: '#fff', background: '#e5c07b', fontSize: 10 })
+    .badge('ƒ', { position: 'top-right', fill: '#98c379' })
+  .done();
+`}>
+
+  <VizMount builder={badgeScene} style={{ height: '140px', width: '100%' }} />
+</CodePreview>
+
+### Options
+
+| Option       | Type            | Default      | Description                           |
+| ------------ | --------------- | ------------ | ------------------------------------- |
+| `position`   | `BadgePosition` | `'top-left'` | Corner to pin the badge to            |
+| `fill`       | `string`        | —            | Text colour                           |
+| `background` | `string`        | —            | Pill background colour (omit for none)|
+| `fontSize`   | `number`        | `10`         | Font size in px                       |
+
+`BadgePosition` is one of `'top-left'` · `'top-right'` · `'bottom-left'` · `'bottom-right'`.
+
+### Declarative form
+
+```ts
+viz().node('n', {
+  badges: [
+    { text: 'C', position: 'top-left', fill: '#fff', background: '#4a9eff' },
+    { text: '⚡', position: 'top-right', fill: '#e64553' },
+  ],
+});
+```
 
 ## Compartmented nodes (UML-style sections)
 

--- a/packages/docs/docs/reference/builder-api.mdx
+++ b/packages/docs/docs/reference/builder-api.mdx
@@ -269,6 +269,7 @@ Returned inside the `.compartment(id, cb)` callback. All methods return `this` f
 | ------------------- | ------------------------------------------------------------------- |
 | `.onClick(handler)` | Attach click handler `(id, node) => void`                           |
 | `.tooltip(content)` | Hover tooltip — `string` or `{ title?, sections: {label,value}[] }` |
+| `.badge(text, opts?)` | Text badge pinned to a corner — see [VizNodeBadge](/docs/reference/types#viznodebadge) |
 
 ### Animation
 

--- a/packages/docs/docs/reference/types.mdx
+++ b/packages/docs/docs/reference/types.mdx
@@ -50,6 +50,7 @@ A node in the scene graph.
 | `container?`  | `ContainerConfig`          | Container configuration                                                                         |
 | `ports?`      | `NodePort[]`               | Explicit connection ports                                                                       |     | `compartments?` | `VizNodeCompartment[]` | Horizontal sections (UML-style). See [VizNodeCompartment](#viznodecompartment) |
 | `tooltip?`    | `TooltipContent`           | Tooltip shown on hover/focus. See [TooltipContent](#tooltipcontent)                             |
+| `badges?`     | `VizNodeBadge[]`           | Text badges pinned to corners. See [VizNodeBadge](#viznodebadge)                                |
 
 ---
 
@@ -278,6 +279,26 @@ type TooltipContent = string | { title?: string; sections: TooltipSection[] };
 | ------- | -------- | ----------------- |
 | `label` | `string` | Key / label text  |
 | `value` | `string` | Value / info text |
+
+---
+
+## VizNodeBadge {#viznodebadge}
+
+A small text indicator pinned to a corner of a node shape.
+
+| Field         | Type            | Description                                  |
+| ------------- | --------------- | -------------------------------------------- |
+| `text`        | `string`        | 1–2 character badge text                      |
+| `position`    | `BadgePosition` | Corner: `'top-left'` \| `'top-right'` \| `'bottom-left'` \| `'bottom-right'` |
+| `fill?`       | `string`        | Text color                                   |
+| `background?` | `string`        | Optional pill background color               |
+| `fontSize?`   | `number`        | Font size in px (default 10)                 |
+
+### BadgePosition {#badgeposition}
+
+```typescript
+type BadgePosition = 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right';
+```
 
 ---
 


### PR DESCRIPTION
Pin 1-2 character indicators to node corners via .badge(text, opts?). Supports four positions (top-left, top-right, bottom-left, bottom-right), custom fill/background/fontSize, and both fluent + declarative APIs.

- BadgePosition type and VizNodeBadge interface in types.ts
- badge() method on NodeBuilder (fluent) and badges option (declarative)
- DOM reconciliation and SVG export rendering
- 11 new tests (467 total, all passing)
- Docs: types.mdx, builder-api.mdx, nodes-and-shapes.mdx how-to, READMEs

closes #108  
 